### PR TITLE
[fix] init client on GamesList reload

### DIFF
--- a/frontend/src/components/GamesList.js
+++ b/frontend/src/components/GamesList.js
@@ -3,16 +3,20 @@ import { withRouter } from 'react-router';
 import { Card } from './Card';
 
 import './GamesList.scss'
+import * as Colyseus from "colyseus.js/dist/colyseus";
 class GamesList extends React.Component {
 
   constructor(props) {
     super(props);
-
     this.state = {rooms: []}
+    if (this.props.client) { // we store endpoint to prevent reload
+      localStorage.setItem("endpoint", this.props.client.endpoint)
+    }
   }
 
   componentDidMount(){
-    this.props.client.getAvailableRooms().then(rooms => {
+    const client = this.props.client || new Colyseus.Client(localStorage.getItem("endpoint"))
+    client.getAvailableRooms().then(rooms => {
       this.setState({rooms: rooms})
     }).catch(e => {
       console.log(e)


### PR DESCRIPTION
Fixed the issue #10 .

The Colyseus client was breaking after reloading the page, because props are reset after that.
I use local storage to store the endpoint, and recreate a new Client once page is refreshed.

Let me know if this works for you @F1nnM 